### PR TITLE
Install native dependencies for ffi gem

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
 
+# This is needed as native dependencies for the ffi gem
+apk add --update build-base libffi-dev
+
 gem install easol-canvas
 canvas lint


### PR DESCRIPTION
After adding sassc, which has the ffi gem as a dependency, the docker
container on the GitHub Action has been failing and throwing an error.

Found this GitHub issue comment useful:

https://github.com/ffi/ffi/issues/485#issuecomment-209778567