### PR TITLE
Use specific version of `easol-canvas` gem

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,5 +3,6 @@
 # This is needed as native dependencies for the ffi gem
 apk add --update build-base libffi-dev
 
-gem install easol-canvas
+gem install easol-canvas --version='2.2.0'
+
 canvas lint


### PR DESCRIPTION
💁 Blindly installing `easol-canvas` can have unintended consequences, e.g. v3.0.0 now requires Dart Sass. This version should probably be configurable via the action itself.