### PR TITLE
Use dartsass version

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,10 @@
 #!/bin/sh
 
-# This is needed as native dependencies for the ffi gem
-apk add --update build-base libffi-dev
+# This is needed as native dependencies for dartsass
+wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
+wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.34-r0/glibc-2.34-r0.apk
+apk add glibc-2.34-r0.apk
 
-gem install easol-canvas --version='2.2.0'
+gem install easol-canvas --version='~> 3.0.0'
 
 canvas lint


### PR DESCRIPTION
This updates the latest easol-canvas gem, and makes sure we install the required dependencies.

Any suggestions on how to test this? I tried using https://github.com/nektos/act to run it locally, but its not even running the current action correctly.