### PR TITLE
Update easol-canvas to v3.1

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,6 @@ wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerr
 wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.34-r0/glibc-2.34-r0.apk
 apk add glibc-2.34-r0.apk
 
-gem install easol-canvas --version='~> 3.0.0'
+gem install easol-canvas --version='~> 3.0'
 
 canvas lint


### PR DESCRIPTION
The latest version of canvas is v3.1.0, which allows the
currency_switcher tag when validating Liquid.

Since https://github.com/easolhq/canvas-linter-action/pull/3, we are
now specifying the exact version of the `easol-canvas` gem.
This means there will be some extra steps when there is a an update
the the canvas gem. Each time there is an update, we'll need to do
the following:

1. Bump the `easol-canvas` gem version.
2. Update `easolhq/canvas-linter-action` to use the new gem version.
3. Update the theme's `.github/workflows/lint.yml` to use the new
   version of canvas-linter-action.

This might be cumbersome and also means that existing themes that don't
update their canvas-linter-action version won't benefit from the latest
validation checks.

This commit proposes we make the gem version more generic and only
require this linter action to to be updated when there major version
changes on the gem.