### PR TITLE
Update easol-canvas to v4.x

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,6 @@ wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerr
 wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.34-r0/glibc-2.34-r0.apk
 apk add glibc-2.34-r0.apk
 
-gem install easol-canvas --version='~> 3.0'
+gem install easol-canvas --version='~> 4.0'
 
 canvas lint


### PR DESCRIPTION
The latest version of the canvas gem is v4.0.0, which enforces custom type keys to be defined in lowercase.

This is a breaking-style change, requiring the major version change.