### PR TITLE
Use ruby slim image instead of alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM ruby:3.2.1-alpine
+FROM ruby:3.1.4-slim
+
+RUN apt update && apt install -y build-essential && rm -rf /var/lib/apt/lists/*
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,5 @@
 #!/bin/sh
 
-# This is needed as native dependencies for dartsass
-wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
-wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.34-r0/glibc-2.34-r0.apk
-apk add glibc-2.34-r0.apk
-
 gem install easol-canvas --version='~> 4.1'
 
 canvas lint


### PR DESCRIPTION
We are seeing the following error when this Github action is executed:

```
ERROR: glibc-2.34-r0: trying to overwrite etc/nsswitch.conf owned by alpine-baselayout-data-3.2.0-r23.
```

There seems to be a problem when it attempts to install glibc, which is needed as a native dependency for dartsass.

We are also seeing this error when installing native dependencies for the racc gem, which is a dependency of nokogiri:

```
current directory: /usr/local/bundle/gems/racc-1.7.3/ext/racc/cparse make DESTDIR\= sitearchdir\=./.gem.20231114-7-jo9434 sitelibdir\=./.gem.20231114-7-jo9434 clean current directory: /usr/local/bundle/gems/racc-1.7.3/ext/racc/cparse make DESTDIR\= sitearchdir\=./.gem.20231114-7-jo9434 sitelibdir\=./.gem.20231114-7-jo9434 make failedNo such file or directory - make
```

This commit solves both these errors by using the base image for ruby, instead of the alpine image. The base image is about 10x larger but solves the problem and doesn't seem to slow down the build too much.

Targeting ruby v3.1.4, as this matches the version we currently use in the easol Rails app.